### PR TITLE
fix(frontend): improve eslint-prettier config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,12 @@ module.exports = {
     browser: true,
     es2021: true
   },
-  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'prettier',
+    'prettier/react'
+  ],
   parserOptions: {
     ecmaFeatures: {
       jsx: true
@@ -12,7 +17,7 @@ module.exports = {
     ecmaVersion: 12,
     sourceType: 'module'
   },
-  plugins: ['react'],
+  plugins: ['react', 'prettier'],
   rules: {
     'react/prop-types': 'off',
     'react/react-in-jsx-scope': 'off'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,12 @@
 {
-  "semi": true,
   "tabWidth": 2,
   "printWidth": 80,
-  "singleQuote": true,
+  "endOfLine": "auto",
+  "arrowParens": "avoid",
   "trailingComma": "none",
+  "semi": true,
+  "useTabs": false,
+  "singleQuote": true,
+  "bracketSpacing": true,
   "jsxBracketSameLine": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "window.zoomLevel": 1,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.formatOnSave": true,
-    "editor.formatOnPaste": false
+  "window.zoomLevel": 1,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+    autoprefixer: {}
+  }
+};


### PR DESCRIPTION
I've improved a bit the config of eslint/prettier.

Ran `yarn run lint` and `yarn run format` to fix small issues related to accomplishing with the config specified above.
I think it's all clean by now.

Let's see while we add more code to the codebase if everything is okay or if we need to improve it on the near future.